### PR TITLE
On update in-cart quantity remains if qty still correct

### DIFF
--- a/includes/classes/shopping_cart.php
+++ b/includes/classes/shopping_cart.php
@@ -1777,14 +1777,6 @@ class shoppingCart extends base {
           $adjust_max= 'true';
         } else {
         if ($add_max != 0) {
-// bof: adjust new quantity to be same as current in stock
-            if (STOCK_ALLOW_CHECKOUT == 'false' && ($new_qty + $cart_qty > $chk_current_qty)) {
-                $adjust_new_qty = 'true';
-                $alter_qty = $chk_current_qty - $cart_qty;
-                $new_qty = ($alter_qty > 0 ? $alter_qty : 0);
-                $messageStack->add_session('shopping_cart', ($this->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($_POST['products_id'][$i]), 'caution');
-            }
-// eof: adjust new quantity to be same as current in stock
           // adjust quantity if needed
         switch (true) {
           case ($new_qty == $current_qty): // no change
@@ -1808,6 +1800,13 @@ class shoppingCart extends base {
           default:
             $adjust_max= 'false';
           }
+          
+// bof: notify about adjustment to new quantity to be same as current in stock or maximum to add
+          if ($adjust_max == 'true') {
+            $messageStack->add_session('shopping_cart', ($_SESSION['cart']->display_debug_messages ? 'FUNCTION ' . __FUNCTION__ . ': ' : '') . WARNING_PRODUCT_QUANTITY_ADJUSTED . zen_get_products_name($_POST['products_id'][$i]), 'caution');
+          }
+// eof: notify about adjustment to new quantity to be same as current in stock or maximum to add
+          
           $attributes = ($_POST['id'][$_POST['products_id'][$i]]) ? $_POST['id'][$_POST['products_id'][$i]] : '';
           $this->add_cart($_POST['products_id'][$i], $new_qty, $attributes, false);
         } else {


### PR DESCRIPTION
Fixes #1163

In an update performed to notify customers that the quantity in the cart had been modified (primarily addressing when adding product to the cart), the same code had been applied to the actionUpdateProduct function which if before the refresh the quantity in the cart plus the quantity to which it is to be set is greater than the available stock, then the quantity to be presented would be modified.

IE: store is setup to not allow going "negative" (allow checkout if out-of-stock is false), if a product has 10 in stock, 9 are added to the cart, the cart is then visited, and while on the cart if the refresh button is pressed, the quantity of that product would become 1. 

The above change removes that code but maintains notification to the customer if the quantity were adjusted for reasons such as attempting to add more than what is in stock or more than the maximum allowable or in other words if the quantity has been modified to be the quantity that currently existed in the cart or the maximum allowed.
