### PR TITLE
Support ISO-8601 style date-of-birth date

### DIFF
--- a/includes/modules/create_account.php
+++ b/includes/modules/create_account.php
@@ -110,6 +110,10 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
 
   if (ACCOUNT_DOB == 'true') {
     if (ENTRY_DOB_MIN_LENGTH > 0 or !empty($_POST['dob'])) {
+      if (preg_match('/^([0-9]{4})(|-|\/)([0-9]{2})\2([0-9]{2})$/', $dob)) {
+        $_POST['dob'] = date(DATE_FORMAT, strtotime($dob));
+        $dob = date(DATE_FORMAT, strtotime($dob));
+      }
       if (substr_count($dob,'/') > 2 || checkdate((int)substr(zen_date_raw($dob), 4, 2), (int)substr(zen_date_raw($dob), 6, 2), (int)substr(zen_date_raw($dob), 0, 4)) == false) {
         $error = true;
         $messageStack->add('create_account', ENTRY_DATE_OF_BIRTH_ERROR);

--- a/includes/modules/create_account.php
+++ b/includes/modules/create_account.php
@@ -111,8 +111,7 @@ if (isset($_POST['action']) && ($_POST['action'] == 'process')) {
   if (ACCOUNT_DOB == 'true') {
     if (ENTRY_DOB_MIN_LENGTH > 0 or !empty($_POST['dob'])) {
       if (preg_match('/^([0-9]{4})(|-|\/)([0-9]{2})\2([0-9]{2})$/', $dob)) {
-        $_POST['dob'] = date(DATE_FORMAT, strtotime($dob));
-        $dob = date(DATE_FORMAT, strtotime($dob));
+        $_POST['dob'] = $dob = date(DATE_FORMAT, strtotime($dob));
       }
       if (substr_count($dob,'/') > 2 || checkdate((int)substr(zen_date_raw($dob), 4, 2), (int)substr(zen_date_raw($dob), 6, 2), (int)substr(zen_date_raw($dob), 0, 4)) == false) {
         $error = true;


### PR DESCRIPTION
Support date of birth collection from "cell phones" as suggested in the forum: https://www.zen-cart.com/showthread.php?222560-New-customer-using-smartphone-Date-of-Birth-info-not-accepted&p=1333443#post1333443

With comment incorporated to use an inline assignment rather than to perform a recalculation for the same value to reduce two calls to the date function down to one being assigned to an in scope variable with that value then being assigned to the associated $_POST.

Source of the issue appears to be by the use of `<input type="date" />` in the template file which returns an ISO-8601 styled date.  This date style may not conform with the date format "recommended" to the visitor.  This change does not prevent a guest from entering the data in the ISO-8601 (or expanded as provided by this code) when typing in the number, but it does support the use of "javascript" style date pickers to provide the date in a format understandable for further processing.

An ISO-8601 specifically formatted date would be one that has a dash (-) only between dates and does not include the additional characters supported by the incorporated regex.  To make this regex only recognize ISO-8601 "alternate" formats, change `(|-|\/)` to `(-)`, otherwise the existing regex permits all numbers to be "pressed" together, to have a dash (-) or to have a forward slash (/); however, it is expected that the same symbol/method is used for each separator (or lack of), otherwise the date is considered incorrectly entered.