### PR TITLE
Clean up of code (#17)

### DIFF
--- a/includes/modules/featured_products.php
+++ b/includes/modules/featured_products.php
@@ -18,15 +18,15 @@ $list_of_products = '';
 $featured_products_query = '';
 $display_limit = '';
 
-if ( (($manufacturers_id > 0 && $_GET['filter_id'] == 0) || (isset($_GET['music_genre_id']) && $_GET['music_genre_id'] > 0) || (isset($_GET['record_company_id']) && $_GET['record_company_id'] > 0)) || (!isset($new_products_category_id) || $new_products_category_id == '0') ) {
-  $featured_products_query = "select distinct p.products_id, p.products_image, pd.products_name, p.master_categories_id
-                           from (" . TABLE_PRODUCTS . " p
-                           left join " . TABLE_FEATURED . " f on p.products_id = f.products_id
-                           left join " . TABLE_PRODUCTS_DESCRIPTION . " pd on p.products_id = pd.products_id )
-                           where p.products_id = f.products_id
-                           and p.products_id = pd.products_id
-                           and p.products_status = 1 and f.status = 1
-                           and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+if ( (($manufacturers_id > 0 && empty($_GET['filter_id'])) || !empty($_GET['music_genre_id']) || !empty($_GET['record_company_id'])) || empty($new_products_category_id) ) {
+  $featured_products_query = "SELECT DISTINCT p.products_id, p.products_image, pd.products_name, p.master_categories_id
+                           FROM (" . TABLE_PRODUCTS . " p
+                           LEFT JOIN " . TABLE_FEATURED . " f ON p.products_id = f.products_id
+                           LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON p.products_id = pd.products_id )
+                           WHERE p.products_id = f.products_id
+                           AND p.products_id = pd.products_id
+                           AND p.products_status = 1 AND f.status = 1
+                           AND pd.language_id = " . (int)$_SESSION['languages_id'];
 } else {
   // get all products and cPaths in this subcat tree
   $productsInCategory = zen_get_categories_products_list( (($manufacturers_id > 0 && $_GET['filter_id'] > 0) ? zen_get_generated_category_path_rev($_GET['filter_id']) : $cPath), false, true, 0, $display_limit);
@@ -37,15 +37,15 @@ if ( (($manufacturers_id > 0 && $_GET['filter_id'] == 0) || (isset($_GET['music_
       $list_of_products .= $key . ', ';
     }
     $list_of_products = substr($list_of_products, 0, -2); // remove trailing comma
-    $featured_products_query = "select distinct p.products_id, p.products_image, pd.products_name, p.master_categories_id
-                                from (" . TABLE_PRODUCTS . " p
-                                left join " . TABLE_FEATURED . " f on p.products_id = f.products_id
-                                left join " . TABLE_PRODUCTS_DESCRIPTION . " pd on p.products_id = pd.products_id)
-                                where p.products_id = f.products_id
-                                and p.products_id = pd.products_id
-                                and p.products_status = 1 and f.status = 1
-                                and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'
-                                and p.products_id in (" . $list_of_products . ")";
+    $featured_products_query = "SELECT DISTINCT p.products_id, p.products_image, pd.products_name, p.master_categories_id
+                                FROM (" . TABLE_PRODUCTS . " p
+                                LEFT JOIN " . TABLE_FEATURED . " f ON p.products_id = f.products_id
+                                LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON p.products_id = pd.products_id)
+                                WHERE p.products_id = f.products_id
+                                AND p.products_id = pd.products_id
+                                AND p.products_status = 1 AND f.status = 1
+                                AND pd.language_id = " . (int)$_SESSION['languages_id'] . "
+                                AND p.products_id IN (" . $list_of_products . ")";
   }
 }
 if ($featured_products_query != '') $featured_products = $db->ExecuteRandomMulti($featured_products_query, MAX_DISPLAY_SEARCH_RESULTS_FEATURED);
@@ -89,4 +89,4 @@ if ($num_products_count > 0) {
     $zc_show_featured = true;
   }
 }
-?>
+

--- a/includes/modules/new_products.php
+++ b/includes/modules/new_products.php
@@ -19,16 +19,16 @@ $new_products_query = '';
 
 $display_limit = zen_get_new_date_range();
 
-if ( (($manufacturers_id > 0 && $_GET['filter_id'] == 0) || (isset($_GET['music_genre_id']) && $_GET['music_genre_id'] > 0) || (isset($_GET['record_company_id']) && $_GET['record_company_id'] > 0)) || (!isset($new_products_category_id) || $new_products_category_id == '0') ) {
-  $new_products_query = "select distinct p.products_id, p.products_image, p.products_tax_class_id, pd.products_name,
+if ( (($manufacturers_id > 0 && empty($_GET['filter_id'])) || !empty($_GET['music_genre_id']) || !empty($_GET['record_company_id'])) || empty($new_products_category_id) ) {
+  $new_products_query = "SELECT DISTINCT p.products_id, p.products_image, p.products_tax_class_id, pd.products_name,
                                 p.products_date_added, p.products_price, p.products_type, p.master_categories_id
-                           from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                           where p.products_id = pd.products_id
-                           and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'
-                           and   p.products_status = 1 " . $display_limit;
+                           FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
+                           WHERE p.products_id = pd.products_id
+                           AND pd.language_id = " . (int)$_SESSION['languages_id'] . "
+                           AND   p.products_status = 1 " . $display_limit;
 } else {
   // get all products and cPaths in this subcat tree
-  $productsInCategory = zen_get_categories_products_list( (($manufacturers_id > 0 && $_GET['filter_id'] > 0) ? zen_get_generated_category_path_rev($_GET['filter_id']) : $cPath), false, true, 0, $display_limit);
+  $productsInCategory = zen_get_categories_products_list( (($manufacturers_id > 0 && !empty($_GET['filter_id'])) ? zen_get_generated_category_path_rev($_GET['filter_id']) : $cPath), false, true, 0, $display_limit);
 
   if (is_array($productsInCategory) && sizeof($productsInCategory) > 0) {
     // build products-list string to insert into SQL query
@@ -37,13 +37,13 @@ if ( (($manufacturers_id > 0 && $_GET['filter_id'] == 0) || (isset($_GET['music_
     }
     $list_of_products = substr($list_of_products, 0, -2); // remove trailing comma
 
-    $new_products_query = "select distinct p.products_id, p.products_image, p.products_tax_class_id, pd.products_name,
+    $new_products_query = "SELECT DISTINCT p.products_id, p.products_image, p.products_tax_class_id, pd.products_name,
                                   p.products_date_added, p.products_price, p.products_type, p.master_categories_id
-                           from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                           where p.products_id = pd.products_id
-                           and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'
-                           and p.products_status = 1
-                           and p.products_id in (" . $list_of_products . ")";
+                           FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
+                           WHERE p.products_id = pd.products_id
+                           AND pd.language_id = " . (int)$_SESSION['languages_id'] . "
+                           AND p.products_status = 1
+                           AND p.products_id in (" . $list_of_products . ")";
   }
 }
 
@@ -80,7 +80,7 @@ if ($num_products_count > 0) {
   }
 
   if ($new_products->RecordCount() > 0) {
-    if (isset($new_products_category_id) && $new_products_category_id != 0) {
+    if (!empty($new_products_category_id)) {
       $category_title = zen_get_categories_name((int)$new_products_category_id);
       $title = '<h2 class="centerBoxHeading">' . sprintf(TABLE_HEADING_NEW_PRODUCTS, strftime('%B')) . ($category_title != '' ? ' - ' . $category_title : '' ) . '</h2>';
     } else {
@@ -89,4 +89,4 @@ if ($num_products_count > 0) {
     $zc_show_new_products = true;
   }
 }
-?>
+

--- a/includes/modules/specials_index.php
+++ b/includes/modules/specials_index.php
@@ -18,15 +18,15 @@ $list_of_products = '';
 $specials_index_query = '';
 $display_limit = '';
 
-if ( (($manufacturers_id > 0 && $_GET['filter_id'] == 0) || (isset($_GET['music_genre_id']) && $_GET['music_genre_id'] > 0) || (isset($_GET['record_company_id']) && $_GET['record_company_id'] > 0)) || (!isset($new_products_category_id) || $new_products_category_id == '0') ) {
-  $specials_index_query = "select p.products_id, p.products_image, pd.products_name, p.master_categories_id
-                           from (" . TABLE_PRODUCTS . " p
-                           left join " . TABLE_SPECIALS . " s on p.products_id = s.products_id
-                           left join " . TABLE_PRODUCTS_DESCRIPTION . " pd on p.products_id = pd.products_id )
-                           where p.products_id = s.products_id
-                           and p.products_id = pd.products_id
-                           and p.products_status = '1' and s.status = 1
-                           and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'";
+if ( (($manufacturers_id > 0 && empty($_GET['filter_id'])) || !empty($_GET['music_genre_id']) || !empty($_GET['record_company_id'])) || empty($new_products_category_id) ) {
+  $specials_index_query = "SELECT p.products_id, p.products_image, pd.products_name, p.master_categories_id
+                           FROM (" . TABLE_PRODUCTS . " p
+                           LEFT JOIN " . TABLE_SPECIALS . " s ON p.products_id = s.products_id
+                           LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON p.products_id = pd.products_id )
+                           WHERE p.products_id = s.products_id
+                           AND p.products_id = pd.products_id
+                           AND p.products_status = 1 AND s.status = 1
+                           AND pd.language_id = " . (int)$_SESSION['languages_id'];
 } else {
   // get all products and cPaths in this subcat tree
   $productsInCategory = zen_get_categories_products_list( (($manufacturers_id > 0 && $_GET['filter_id'] > 0) ? zen_get_generated_category_path_rev($_GET['filter_id']) : $cPath), false, true, 0, $display_limit);
@@ -37,15 +37,15 @@ if ( (($manufacturers_id > 0 && $_GET['filter_id'] == 0) || (isset($_GET['music_
       $list_of_products .= $key . ', ';
     }
     $list_of_products = substr($list_of_products, 0, -2); // remove trailing comma
-    $specials_index_query = "select distinct p.products_id, p.products_image, pd.products_name, p.master_categories_id
-                             from (" . TABLE_PRODUCTS . " p
-                             left join " . TABLE_SPECIALS . " s on p.products_id = s.products_id
-                             left join " . TABLE_PRODUCTS_DESCRIPTION . " pd on p.products_id = pd.products_id )
-                             where p.products_id = s.products_id
-                             and p.products_id = pd.products_id
-                             and p.products_status = '1' and s.status = '1'
-                             and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'
-                             and p.products_id in (" . $list_of_products . ")";
+    $specials_index_query = "SELECT DISTINCT p.products_id, p.products_image, pd.products_name, p.master_categories_id
+                             FROM (" . TABLE_PRODUCTS . " p
+                             LEFT JOIN " . TABLE_SPECIALS . " s ON p.products_id = s.products_id
+                             LEFT JOIN " . TABLE_PRODUCTS_DESCRIPTION . " pd ON p.products_id = pd.products_id )
+                             WHERE p.products_id = s.products_id
+                             AND p.products_id = pd.products_id
+                             AND p.products_status = 1 AND s.status = 1
+                             AND pd.language_id = " . (int)$_SESSION['languages_id'] . "
+                             AND p.products_id in (" . $list_of_products . ")";
   }
 }
 if ($specials_index_query != '') $specials_index = $db->ExecuteRandomMulti($specials_index_query, MAX_DISPLAY_SPECIAL_PRODUCTS_INDEX);
@@ -87,4 +87,3 @@ if ($num_products_count > 0) {
     $zc_show_specials = true;
   }
 }
-?>

--- a/includes/modules/upcoming_products.php
+++ b/includes/modules/upcoming_products.php
@@ -19,20 +19,20 @@ $expected_query = '';
 
 $display_limit = zen_get_upcoming_date_range();
 
-$limit_clause = "  order by " . (EXPECTED_PRODUCTS_FIELD == 'date_expected' ? 'date_expected' : 'products_name') . " " . (EXPECTED_PRODUCTS_SORT == 'asc' ? 'asc' : 'desc') . "
-                   limit " . (int)MAX_DISPLAY_UPCOMING_PRODUCTS;
+$limit_clause = "  ORDER BY " . (EXPECTED_PRODUCTS_FIELD == 'date_expected' ? 'date_expected' : 'products_name') . " " . (EXPECTED_PRODUCTS_SORT == 'asc' ? 'ASC' : 'DESC') . "
+                   LIMIT " . (int)MAX_DISPLAY_UPCOMING_PRODUCTS;
 
-if ( (($manufacturers_id > 0 && $_GET['filter_id'] == 0) || (isset($_GET['music_genre_id']) && $_GET['music_genre_id'] > 0) || (isset($_GET['record_company_id']) && $_GET['record_company_id'] > 0)) || (!isset($new_products_category_id) || $new_products_category_id == '0') ) {
-  $expected_query = "select p.products_id, pd.products_name, products_date_available as date_expected, p.master_categories_id
-                     from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                     where p.products_id = pd.products_id
-                     and p.products_status = 1
-                     and pd.language_id = '" . (int)$_SESSION['languages_id'] . "'" .
+if ( (($manufacturers_id > 0 && empty($_GET['filter_id'])) || !empty($_GET['music_genre_id']) || !empty($_GET['record_company_id'])) || empty($new_products_category_id) ) {
+  $expected_query = "SELECT p.products_id, pd.products_name, products_date_available AS date_expected, p.master_categories_id
+                     FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
+                     WHERE p.products_id = pd.products_id
+                     AND p.products_status = 1
+                     AND pd.language_id = " . (int)$_SESSION['languages_id'] .
                      $display_limit .
                      $limit_clause;
 } else {
   // get all products and cPaths in this subcat tree
-  $productsInCategory = zen_get_categories_products_list( (($manufacturers_id > 0 && $_GET['filter_id'] > 0) ? zen_get_generated_category_path_rev($_GET['filter_id']) : $cPath), false, true, 0, $display_limit);
+  $productsInCategory = zen_get_categories_products_list( (($manufacturers_id > 0 && !empty($_GET['filter_id'])) ? zen_get_generated_category_path_rev($_GET['filter_id']) : $cPath), false, true, 0, $display_limit);
 
   if (is_array($productsInCategory) && sizeof($productsInCategory) > 0) {
     // build products-list string to insert into SQL query
@@ -41,12 +41,12 @@ if ( (($manufacturers_id > 0 && $_GET['filter_id'] == 0) || (isset($_GET['music_
     }
     $list_of_products = substr($list_of_products, 0, -2); // remove trailing comma
 
-    $expected_query = "select p.products_id, pd.products_name, products_date_available as date_expected, p.master_categories_id
-                       from " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
-                       where p.products_id = pd.products_id
-                       and p.products_id in (" . $list_of_products . ")
-                       and p.products_status = 1
-                       and pd.language_id = '" . (int)$_SESSION['languages_id'] . "' " .
+    $expected_query = "SELECT p.products_id, pd.products_name, products_date_available AS date_expected, p.master_categories_id
+                       FROM " . TABLE_PRODUCTS . " p, " . TABLE_PRODUCTS_DESCRIPTION . " pd
+                       WHERE p.products_id = pd.products_id
+                       AND p.products_id IN (" . $list_of_products . ")
+                       AND p.products_status = 1
+                       AND pd.language_id = " . (int)$_SESSION['languages_id'] .
                        $display_limit .
                        $limit_clause;
   }
@@ -54,10 +54,9 @@ if ( (($manufacturers_id > 0 && $_GET['filter_id'] == 0) || (isset($_GET['music_
 
 if ($expected_query != '') $expected = $db->Execute($expected_query);
 if ($expected_query != '' && $expected->RecordCount() > 0) {
-  while (!$expected->EOF) {
-    if (!isset($productsInCategory[$expected->fields['products_id']])) $productsInCategory[$expected->fields['products_id']] = zen_get_generated_category_path_rev($expected->fields['master_categories_id']);
-    $expectedItems[] = $expected->fields;
-    $expected->MoveNext();
+  foreach ($expected as $expect)
+    if (!isset($productsInCategory[$expect['products_id']])) $productsInCategory[$expect['products_id']] = zen_get_generated_category_path_rev($expect['master_categories_id']);
+    $expectedItems[] = $expect;
   }
   require($template->get_template_dir('tpl_modules_upcoming_products.php', DIR_WS_TEMPLATE, $current_page_base,'templates'). '/' . 'tpl_modules_upcoming_products.php');
 }


### PR DESCRIPTION
Replace (!isset && >0) with !empty,
Replace `!isset || == '0'` with empty,
Capitalize mySql query commands,
Capitalize limit_clause mySql statements
Remove closing php tag

In developer/owner review, comment was made that the combination function of: `isset($var) && $var > 0` could be shortened to `!empty($var)`

Note that other design considerations are that `$_GET[$var]` variable is not to support arrays and would be expected to be sanitized as such prior to code usage, therefore, of the `empty()` considerations, a value of 0, "0", 0.0, '', FALSE, or NULL would be the only ones that would result in a true condition for `empty()` which would be a false condition for `!empty()`. Conversely anything other than those values would result in executing the code that follows and that the variable `$_GET[$var]` would *not* be an array as provided on the URI of any size. 

This commit performs that revision to support strict code operation.

Also included is a removal of single quotes around integer values (reduces database operations of converting the then string integer back to an integer) and using all capital letters for mySql "commands".