### PR TITLE
Incorporate products_id in products with attributes

### DIFF
--- a/admin/option_values.php
+++ b/admin/option_values.php
@@ -216,7 +216,7 @@ switch ($_GET['action']) {
         <div class="row">
             <?php echo zen_draw_form('update_product_attributes', FILENAME_PRODUCTS_OPTIONS_VALUES, 'action=update_product', 'post', 'class="form-horizontal"'); ?>
             <?php echo zen_draw_hidden_field('products_update_id'); ?>
-          <div class="col-sm-6"><?php echo zen_draw_products_pull_down_attributes('products_update_id', 'class="form-control"'); ?></div>
+          <div class="col-sm-6"><?php echo zen_draw_products_pull_down_attributes('products_update_id', 'class="form-control"', [], 'name', null, true); ?></div>
           <div class="col-sm-2">
             <button type="submit" class="btn btn-warning"><?php echo IMAGE_UPDATE; ?></button>
           </div>

--- a/admin/options_name_manager.php
+++ b/admin/options_name_manager.php
@@ -746,7 +746,7 @@ function translate_type_to_name($opt_type)
                         <div class="col-sm-7">
                             <?php
                             echo zen_draw_label(TEXT_SELECT_PRODUCT, 'product_to_update_add', 'class="control-label"') . '<br>';
-                            echo zen_draw_products_pull_down_attributes('product_to_update', 'size="5" class="form-control" id="product_to_update_add" required', '', $products_order_by, $selectedOptionId);
+                            echo zen_draw_products_pull_down_attributes('product_to_update', 'size="5" class="form-control" id="product_to_update_add" required', '', $products_order_by, $selectedOptionId, true);
                             if ($selectedOptionId !== '') {
                                 $products_sort_link = ($products_order_by === 'name' ?
                                     '<a href="' . zen_href_link(FILENAME_OPTIONS_NAME_MANAGER, zen_get_all_get_params(['products_order_by']) . '&products_order_by=model#addOptionValuesOneWrapper') . '">' . TEXT_ORDER_BY . ' ' . TABLE_HEADING_MODEL . '</a>' :
@@ -845,7 +845,7 @@ function translate_type_to_name($opt_type)
                         <div class="col-sm-7">
                             <?php
                             echo zen_draw_label(TEXT_SELECT_PRODUCT, 'product_to_update_delete', 'class="control-label"') . '<br>';
-                            echo zen_draw_products_pull_down_attributes('product_to_update', 'size="5" class="form-control" id="product_to_update_delete" required', '', $products_order_by, $selectedOptionId);
+                            echo zen_draw_products_pull_down_attributes('product_to_update', 'size="5" class="form-control" id="product_to_update_delete" required', '', $products_order_by, $selectedOptionId, true);
                             if ($selectedOptionId !== '') {
                                 $products_sort_link = ($products_order_by === 'name' ?
                                     '<a href="' . zen_href_link(FILENAME_OPTIONS_NAME_MANAGER, zen_get_all_get_params(['products_order_by']) . '&products_order_by=model#deleteOptionValuesOneWrapper') . '">' . TEXT_ORDER_BY . ' ' . TABLE_HEADING_MODEL . '</a>' :

--- a/includes/functions/functions_categories.php
+++ b/includes/functions/functions_categories.php
@@ -384,7 +384,7 @@ function zen_draw_products_pull_down($field_name, $parameters = '', $exclude = [
  * @param int $filter_by_option_name -1|0|option_name_id
  * @return string
  */
-function zen_draw_products_pull_down_attributes($field_name, $parameters = '', $exclude = [], $order_by = 'name', $filter_by_option_name = null)
+function zen_draw_products_pull_down_attributes($field_name, $parameters = '', $exclude = [], $order_by = 'name', $filter_by_option_name = null, $show_id = false)
 {
     global $db, $currencies;
 
@@ -402,10 +402,10 @@ function zen_draw_products_pull_down_attributes($field_name, $parameters = '', $
 
     if ($order_by == 'model') {
         $order_by = 'p.products_model';
-        $output_string = '<option value="%1$u"> %3$s - %2$s (%4$s)</option>'; // format string with model first
+        $output_string = '<option value="%1$u"> %3$s - %2$s (%4$s)' . ($show_id ? ' - ID# $1$u' : '') . '</option>'; // format string with model first
     } else {
         $order_by = 'pd.products_name';
-        $output_string = '<option value="%1$u">%2$s (%3$s) (%4$s)</option>';// format string with name first
+        $output_string = '<option value="%1$u">%2$s (%3$s) (%4$s)' . ($show_id ? ' - ID# $1$u' : '') . '</option>';// format string with name first
     }
 
     $sql = "SELECT distinct p.products_id, pd.products_name, p.products_price" . $new_fields . "


### PR DESCRIPTION
Incorporate ID# into text display

This adds the ability to show the `products_id` into the dropdown/pulldown/select list from function `zen_draw_products_pull_down_attributes`.